### PR TITLE
Fix systemd run before cloud init

### DIFF
--- a/rpm/goat@.service
+++ b/rpm/goat@.service
@@ -3,8 +3,8 @@ Description=GOAT: EC2-%i attach utility
 Documentation=https://github.com/sevagh/goat
 Requires=network.target
 After=network.target
+After=NetworkManager-wait-online.service
 Before=cloud-init.service
-Before=sshd.service
 ConditionPathExists=/usr/sbin/goat
 
 [Service]

--- a/rpm/goat@.service
+++ b/rpm/goat@.service
@@ -1,8 +1,10 @@
 [Unit]
 Description=GOAT: EC2-%i attach utility
 Documentation=https://github.com/sevagh/goat
-Requires=network.target remote-fs.target
-After=network.target remote-fs.target
+Requires=network.target
+After=network.target
+Before=cloud-init.service
+Before=sshd.service
 ConditionPathExists=/usr/sbin/goat
 
 [Service]
@@ -13,4 +15,4 @@ ExecStart=/usr/sbin/goat "%i"
 SyslogIdentifier=goat
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=cloud-init.target


### PR DESCRIPTION
This PR provides the following:

- Fix the unit so that goat runs after the network is up (Refs #2).*
- Improved scheduling so that goat runs before cloud-init. This allows goat to mount /home *before* cloud-init creates user accounts. Similarly due to cloud-init target, this also runs before sshd is started.

* On other RPM distros we might need to add additional lines `After=NetworkManager-wait-online.service` depending on the network-online service name. 

